### PR TITLE
Add Corpse preference Option

### DIFF
--- a/Languages/ChineseSimplified/Keyed/strings.xml
+++ b/Languages/ChineseSimplified/Keyed/strings.xml
@@ -10,4 +10,6 @@
   <ac_animals_pay_attention_label>动物在交互期间将等候训练者</ac_animals_pay_attention_label>
   <ac_animals_pay_attention_note>杜绝训练期间的"你跑我追"</ac_animals_pay_attention_note>
   <ac_nutrition_limit_per_piece>每次训练所用食物的营养上限: {0} (默认 = 0.1)</ac_nutrition_limit_per_piece>
+  <ac_animals_prefer_corpses>动物更喜欢吃尸体</ac_animals_prefer_corpses>
+  <ac_animals_prefer_corpses_note>如果允许在它们的食物政策中，动物会帮你处理掉所有那些讨厌的袭击者尸体</ac_animals_prefer_corpses_note>
 </LanguageData>

--- a/Languages/English/Keyed/strings.xml
+++ b/Languages/English/Keyed/strings.xml
@@ -10,4 +10,6 @@
 	<ac_animals_pay_attention_label>Animals will pay attention to the handler during interaction</ac_animals_pay_attention_label>
 	<ac_animals_pay_attention_note>No more chasing around for half a day when training</ac_animals_pay_attention_note>
 	<ac_nutrition_limit_per_piece>Nutrition limit per piece of food for taming: {0} (default = 0.1)</ac_nutrition_limit_per_piece>
+	<ac_animals_prefer_corpses>Animals prefer eating corpses.</ac_animals_prefer_corpses>
+	<ac_animals_prefer_corpses_note>Animals will dispose all those pesky raider corpses for you, if allowed in their food policy</ac_animals_prefer_corpses_note>
 </LanguageData>

--- a/Languages/German/Keyed/strings.xml
+++ b/Languages/German/Keyed/strings.xml
@@ -10,4 +10,6 @@
 	<ac_animals_pay_attention_label>Die Tiere achten während der Interaktion auf den Pfleger.</ac_animals_pay_attention_label>
 	<ac_animals_pay_attention_note>Kein halbtägiges Herumjagen mehr beim Training</ac_animals_pay_attention_note>
 	<ac_nutrition_limit_per_piece>Nährwertbegrenzung pro Futtermittel zum Zähmen: {0} (default = 0.1)</ac_nutrition_limit_per_piece>
+	<ac_animals_prefer_corpses>Tiere bevorzugen es Leichen zu essen</ac_animals_prefer_corpses>
+	<ac_animals_prefer_corpses_note>Damit entsorgen Tiere automatisch Leichen, falls ihr Speiseplan dies zulässt</ac_animals_prefer_corpses_note>
 </LanguageData>

--- a/Languages/Russian/Keyed/strings.xml
+++ b/Languages/Russian/Keyed/strings.xml
@@ -11,4 +11,6 @@
   <ac_animals_pay_attention_note>Больше не нужно бегать по полдня во время тренировки животного.</ac_animals_pay_attention_note>
   <ac_nutrition_limit_per_piece>Ограничение по питательности единицы пищевого продукта для взаимодействия с животными (по умолчанию: 0.1): {0}</ac_nutrition_limit_per_piece>
 
+	<ac_animals_prefer_corpses>Животные предпочитают поедать трупы..</ac_animals_prefer_corpses>
+	<ac_animals_prefer_corpses_note>Животные избавятся от всех надоедливых трупов налётчиков за вас, если это разрешено их пищевой политикой.</ac_animals_prefer_corpses_note>
 </LanguageData>

--- a/source/AnimalControls16/Patch/FoodUtilityPatches.cs
+++ b/source/AnimalControls16/Patch/FoodUtilityPatches.cs
@@ -103,8 +103,17 @@ namespace AnimalControls.Patch
                         modifier += 25f;
                 }
             }
+
+            if (Settings.animals_prefer_corpses)
+            {
+				if (eater.RaceProps.Eats(FoodTypeFlags.Corpse))
+				{
+					if (foodDef.ingestible.foodType == FoodTypeFlags.Corpse)
+						modifier += 300f;
+				}
+			}	
             //
-            FoodPreferability pref = foodDef.ingestible.preferability;
+			FoodPreferability pref = foodDef.ingestible.preferability;
             switch (pref)
             {
                 case FoodPreferability.DesperateOnlyForHumanlikes:

--- a/source/AnimalControls16/Settings.cs
+++ b/source/AnimalControls16/Settings.cs
@@ -8,14 +8,16 @@ namespace AnimalControls
     {
 
         public static bool allow_feeding_with_plants = true;
+		public static bool animals_prefer_corpses = false;
         public static bool animals_pay_attention = true;
 
-        public static void DoSettingsWindowContents(Rect inRect)
+		public static void DoSettingsWindowContents(Rect inRect)
         {
             Listing_Standard listing_Standard = new Listing_Standard();
             listing_Standard.Begin(inRect);
             listing_Standard.CheckboxLabeled("ac_allow_feeding_with_plants_label".Translate(), ref allow_feeding_with_plants, "ac_allow_feeding_with_plants_note".Translate());
-            listing_Standard.CheckboxLabeled("ac_animals_pay_attention_label".Translate(), ref animals_pay_attention, "ac_animals_pay_attention_note".Translate());
+			listing_Standard.CheckboxLabeled("ac_animals_prefer_corpses".Translate(), ref animals_prefer_corpses, "ac_animals_prefer_corpses_note".Translate());
+			listing_Standard.CheckboxLabeled("ac_animals_pay_attention_label".Translate(), ref animals_pay_attention, "ac_animals_pay_attention_note".Translate());
             listing_Standard.Label("ac_nutrition_limit_per_piece".Translate(Math.Round(AnimalControls.TrainAnimalNutritionLimit, 2).ToString()));
             AnimalControls.TrainAnimalNutritionLimit = listing_Standard.Slider(AnimalControls.TrainAnimalNutritionLimit, 0f, 10f);
             listing_Standard.End();
@@ -26,7 +28,8 @@ namespace AnimalControls
             base.ExposeData();
             Scribe_Values.Look(ref allow_feeding_with_plants, "allow_feeding_with_plants", true, false);
             Scribe_Values.Look(ref animals_pay_attention, "animals_pay_attention", true, false);
-            Scribe_Values.Look(ref AnimalControls.TrainAnimalNutritionLimit, "nutrition_limit_per_piece", 0.1f, false);
+			Scribe_Values.Look(ref animals_prefer_corpses, nameof(animals_prefer_corpses), false, false);
+			Scribe_Values.Look(ref AnimalControls.TrainAnimalNutritionLimit, "nutrition_limit_per_piece", 0.1f, false);
         }
     }
 }


### PR DESCRIPTION
If this option is enabled animals should prefer eating Corpses over other food. 
I added this so animals will eat raiders before decimating my meat pile without having to butcher Humanlikes or getting rid of their clothes. 

In my test with a yorkshire Terrier Food preference for a corpse were 45 points higher than Kibble. 
This should prevent them from running away too far because for each cell distance preference is reduced by 1. 
Pawns will still prefer Kibble for training. 

English and German was text was written by me. Russian and Chinese was translated from english via ChatGpt (GPT-5).